### PR TITLE
Enable the use of kubernetes-dashboard

### DIFF
--- a/config/test/kubernetes-dashboard.yaml
+++ b/config/test/kubernetes-dashboard.yaml
@@ -1,0 +1,328 @@
+# Original at https://raw.githubusercontent.com/kubernetes/dashboard/v2.7.0/aio/deploy/recommended.yaml
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Modifications by CoreKube team, 2023.
+#
+# - Modified the ClusterRoleBinding of kubernetes-dashboard to have the
+#   cluster-admin role and thus admin access to all metrics.
+# - Modified the arguments to kubernetes-dashboard to contain --enable-
+#   skip-login (allowing user to use kubernetes-dashboard service account
+#   to skip login, which now has admin privs due to first change).
+# - Also modified the arguments to contain --enable-insecure-login, which
+#   allows you to see the login page and skip it even on HTTP.
+#
+# This YAML is based on v2.7.0 of kubernetes-dashboard.
+# v3 of kubernetes-dashboard was released very recently, but it changes the
+# dependencies and only complicated the installation process while still
+# being functionally identical, so we're going with the latest v2.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubernetes-dashboard
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard
+  namespace: kubernetes-dashboard
+
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard
+  namespace: kubernetes-dashboard
+spec:
+  ports:
+    - port: 443
+      targetPort: 8443
+  selector:
+    k8s-app: kubernetes-dashboard
+
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard-certs
+  namespace: kubernetes-dashboard
+type: Opaque
+
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard-csrf
+  namespace: kubernetes-dashboard
+type: Opaque
+data:
+  csrf: ""
+
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard-key-holder
+  namespace: kubernetes-dashboard
+type: Opaque
+
+---
+
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard-settings
+  namespace: kubernetes-dashboard
+
+---
+
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard
+  namespace: kubernetes-dashboard
+rules:
+  # Allow Dashboard to get, update and delete Dashboard exclusive secrets.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["kubernetes-dashboard-key-holder", "kubernetes-dashboard-certs", "kubernetes-dashboard-csrf"]
+    verbs: ["get", "update", "delete"]
+    # Allow Dashboard to get and update 'kubernetes-dashboard-settings' config map.
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["kubernetes-dashboard-settings"]
+    verbs: ["get", "update"]
+    # Allow Dashboard to get metrics.
+  - apiGroups: [""]
+    resources: ["services"]
+    resourceNames: ["heapster", "dashboard-metrics-scraper"]
+    verbs: ["proxy"]
+  - apiGroups: [""]
+    resources: ["services/proxy"]
+    resourceNames: ["heapster", "http:heapster:", "https:heapster:", "dashboard-metrics-scraper", "http:dashboard-metrics-scraper"]
+    verbs: ["get"]
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard
+rules:
+  # Allow Metrics Scraper to get metrics from the Metrics server
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods", "nodes"]
+    verbs: ["get", "list", "watch"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard
+  namespace: kubernetes-dashboard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kubernetes-dashboard
+subjects:
+  - kind: ServiceAccount
+    name: kubernetes-dashboard
+    namespace: kubernetes-dashboard
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubernetes-dashboard
+  namespace: kubernetes-dashboard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  # Modification by CoreKube team to make kubernetes-dashboard service account
+  # have full admin access to k8s (dangerous!! only for demo purposes)
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: kubernetes-dashboard
+    namespace: kubernetes-dashboard
+    
+---
+
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard
+  namespace: kubernetes-dashboard
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      k8s-app: kubernetes-dashboard
+  template:
+    metadata:
+      labels:
+        k8s-app: kubernetes-dashboard
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: kubernetes-dashboard
+          image: kubernetesui/dashboard:v2.7.0
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8443
+              protocol: TCP
+          args:
+            - --auto-generate-certificates
+            - --namespace=kubernetes-dashboard
+            # Uncomment the following line to manually specify Kubernetes API server Host
+            # If not specified, Dashboard will attempt to auto discover the API server and connect
+            # to it. Uncomment only if the default does not work.
+            # - --apiserver-host=http://my-address:port
+            # Modification by CoreKube team to allow HTTP login and using admin login
+            - --enable-insecure-login
+            - --enable-skip-login
+          volumeMounts:
+            - name: kubernetes-dashboard-certs
+              mountPath: /certs
+              # Create on-disk volume to store exec logs
+            - mountPath: /tmp
+              name: tmp-volume
+          livenessProbe:
+            httpGet:
+              scheme: HTTPS
+              path: /
+              port: 8443
+            initialDelaySeconds: 30
+            timeoutSeconds: 30
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 1001
+            runAsGroup: 2001
+      volumes:
+        - name: kubernetes-dashboard-certs
+          secret:
+            secretName: kubernetes-dashboard-certs
+        - name: tmp-volume
+          emptyDir: {}
+      serviceAccountName: kubernetes-dashboard
+      nodeSelector:
+        "kubernetes.io/os": linux
+      # Comment the following tolerations if Dashboard must not be deployed on master
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  labels:
+    k8s-app: dashboard-metrics-scraper
+  name: dashboard-metrics-scraper
+  namespace: kubernetes-dashboard
+spec:
+  ports:
+    - port: 8000
+      targetPort: 8000
+  selector:
+    k8s-app: dashboard-metrics-scraper
+
+---
+
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  labels:
+    k8s-app: dashboard-metrics-scraper
+  name: dashboard-metrics-scraper
+  namespace: kubernetes-dashboard
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      k8s-app: dashboard-metrics-scraper
+  template:
+    metadata:
+      labels:
+        k8s-app: dashboard-metrics-scraper
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: dashboard-metrics-scraper
+          image: kubernetesui/metrics-scraper:v1.0.8
+          ports:
+            - containerPort: 8000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              scheme: HTTP
+              path: /
+              port: 8000
+            initialDelaySeconds: 30
+            timeoutSeconds: 30
+          volumeMounts:
+          - mountPath: /tmp
+            name: tmp-volume
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 1001
+            runAsGroup: 2001
+      serviceAccountName: kubernetes-dashboard
+      nodeSelector:
+        "kubernetes.io/os": linux
+      # Comment the following tolerations if Dashboard must not be deployed on master
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      volumes:
+        - name: tmp-volume
+          emptyDir: {}

--- a/scripts/ck_5g_master.sh
+++ b/scripts/ck_5g_master.sh
@@ -132,6 +132,13 @@ echo "All nodes joined"
 # that we can get from ipinfo.io
 echo "Kubernetes is ready at: http://$(curl ipinfo.io -s | jq -r .hostname):8080/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#/workloads?namespace=default"
 
+# Also make the link display on every SSH login too, for convenience:
+cat <<ASD >> /users/${username}/.ssh/rc
+echo "\033[34m==================\033[0m"
+echo "\033[1mCoreKube Dashboard:\033[0m http://$(curl -s ipinfo.io | jq -r .hostname):8080/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#/workloads?namespace=default"
+echo "\033[34m==================\033[0m"
+ASD
+
 #Deploy metrics server
 sudo kubectl create -f config/test/metrics-server.yaml
 # Deploy Test Core

--- a/scripts/ck_5g_master.sh
+++ b/scripts/ck_5g_master.sh
@@ -82,13 +82,12 @@ source <(kubectl completion bash)
 
 # kubectl get nodes --kubeconfig=${KUBEHOME}/admin.conf -s https://155.98.36.111:6443
 # Install dashboard: https://github.com/kubernetes/dashboard
-# TODO: why are we using this specific release? Would the latest get us anything?
 echo "Launching Kubernetes Dashboard..."
-sudo kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v1.10.1/src/deploy/recommended/kubernetes-dashboard.yaml
+sudo kubectl apply -f https://gist.githubusercontent.com/yutotakano/f6cce5db44da105b2dab4e113c0653e1/raw/04f426ac2e617da72c919f0c4b2e8e904d87e832/kubernetes-dashboard-v2.7.0-corekube.yaml
  
 # run the proxy to make the dashboard portal accessible from outside
 echo "Running proxy at port 8080..."
-sudo kubectl proxy  --kubeconfig=${KUBEHOME}/admin.conf -p 8080 &
+sudo kubectl proxy -p 8080 --address='0.0.0.0' --accept-hosts='^*$' &
 
 # jid for json parsing.
 export GOPATH=${WORKINGDIR}/go/gopath
@@ -129,15 +128,9 @@ do
 done
 echo "All nodes joined"
 
-dashboard_endpoint=`kubectl get endpoints --all-namespaces |grep dashboard|awk '{print $3}'`
-dashboard_credential=`kubectl -n kube-system describe secret $(kubectl -n kube-system get secret | grep admin-user | awk '{print $1}') |grep token: | awk '{print $2}'`
-
-echo "Kubernetes is ready at: http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/#!/login"
-
-# optional address
-echo "kubernetes dashboard endpoint: $dashboard_endpoint"
-# dashboard credential
-echo "And this is the dashboard credential: $dashboard_credential"
+# Display for the end-user where the Kubernetes dashboard is, using our pcXXX hostname
+# that we can get from ipinfo.io
+echo "Kubernetes is ready at: http://$(curl ipinfo.io -s | jq -r .hostname):8080/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#/workloads?namespace=default"
 
 #Deploy metrics server
 sudo kubectl create -f config/test/metrics-server.yaml

--- a/scripts/ck_5g_master.sh
+++ b/scripts/ck_5g_master.sh
@@ -82,8 +82,12 @@ source <(kubectl completion bash)
 
 # kubectl get nodes --kubeconfig=${KUBEHOME}/admin.conf -s https://155.98.36.111:6443
 # Install dashboard: https://github.com/kubernetes/dashboard
+# v3 of kubernetes-dashboard has many software dependencies like Nginx Ingress and the set up process
+# changes drastically. v2 serves the exact same functionality with a slightly more straightforward setup,
+# so we will use the latest v2 (2.7.0) recommended YAML file as a base.
+# It has been modified to allow HTTP access and to allow admin login without credentials.
 echo "Launching Kubernetes Dashboard..."
-sudo kubectl apply -f https://gist.githubusercontent.com/yutotakano/f6cce5db44da105b2dab4e113c0653e1/raw/04f426ac2e617da72c919f0c4b2e8e904d87e832/kubernetes-dashboard-v2.7.0-corekube.yaml
+sudo kubectl apply -f https://gist.githubusercontent.com/yutotakano/f6cce5db44da105b2dab4e113c0653e1/raw/c6b15225869f7daca8c306395f7583c3454e9dd7/kubernetes-dashboard-v2.7.0-corekube.yaml
  
 # run the proxy to make the dashboard portal accessible from outside
 echo "Running proxy at port 8080..."
@@ -136,6 +140,8 @@ echo "Kubernetes is ready at: http://$(curl ipinfo.io -s | jq -r .hostname):8080
 cat <<ASD >> /users/${username}/.ssh/rc
 echo "\033[34m==================\033[0m"
 echo "\033[1mCoreKube Dashboard:\033[0m http://$(curl -s ipinfo.io | jq -r .hostname):8080/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#/workloads?namespace=default"
+echo "  When prompted for authentication, press "Skip" to use the built-in admin account.
+echo "  \033[31;1mWarning:\033[0m This deployment is for research purposes only. Having a publicly accessible admin Kubernetes dashboard like this is \033[31mdangerous\033[0m for anything else.
 echo "\033[34m==================\033[0m"
 ASD
 

--- a/scripts/ck_5g_master.sh
+++ b/scripts/ck_5g_master.sh
@@ -81,13 +81,15 @@ sudo kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Do
 source <(kubectl completion bash)
 
 # kubectl get nodes --kubeconfig=${KUBEHOME}/admin.conf -s https://155.98.36.111:6443
+
 # Install dashboard: https://github.com/kubernetes/dashboard
 # v3 of kubernetes-dashboard has many software dependencies like Nginx Ingress and the set up process
 # changes drastically. v2 serves the exact same functionality with a slightly more straightforward setup,
 # so we will use the latest v2 (2.7.0) recommended YAML file as a base.
-# It has been modified to allow HTTP access and to allow admin login without credentials.
+# It has been modified to allow HTTP access and to allow admin login without credentials. More details in
+# the file itself.
 echo "Launching Kubernetes Dashboard..."
-sudo kubectl apply -f https://gist.githubusercontent.com/yutotakano/f6cce5db44da105b2dab4e113c0653e1/raw/c6b15225869f7daca8c306395f7583c3454e9dd7/kubernetes-dashboard-v2.7.0-corekube.yaml
+sudo kubectl apply -f config/test/kubernetes-dashboard.yaml
  
 # run the proxy to make the dashboard portal accessible from outside
 echo "Running proxy at port 8080..."

--- a/scripts/ck_5g_master.sh
+++ b/scripts/ck_5g_master.sh
@@ -142,8 +142,8 @@ echo "Kubernetes is ready at: http://$(curl ipinfo.io -s | jq -r .hostname):8080
 cat <<ASD >> /users/${username}/.ssh/rc
 echo "\033[34m==================\033[0m"
 echo "\033[1mCoreKube Dashboard:\033[0m http://$(curl -s ipinfo.io | jq -r .hostname):8080/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#/workloads?namespace=default"
-echo "  When prompted for authentication, press "Skip" to use the built-in admin account.
-echo "  \033[31;1mWarning:\033[0m This deployment is for research purposes only. Having a publicly accessible admin Kubernetes dashboard like this is \033[31mdangerous\033[0m for anything else.
+echo "  When prompted for authentication, press \"Skip\" to use the built-in admin account."
+echo "  \033[31;1mWarning:\033[0m This deployment is for research purposes only. Having a publicly accessible admin Kubernetes dashboard like this is \033[31mdangerous\033[0m for anything else."
 echo "\033[34m==================\033[0m"
 ASD
 

--- a/scripts/ck_master.sh
+++ b/scripts/ck_master.sh
@@ -142,8 +142,8 @@ echo "Kubernetes is ready at: http://$(curl ipinfo.io -s | jq -r .hostname):8080
 cat <<ASD >> /users/${username}/.ssh/rc
 echo "\033[34m==================\033[0m"
 echo "\033[1mCoreKube Dashboard:\033[0m http://$(curl -s ipinfo.io | jq -r .hostname):8080/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#/workloads?namespace=default"
-echo "  When prompted for authentication, press "Skip" to use the built-in admin account.
-echo "  \033[31;1mWarning:\033[0m This deployment is for research purposes only. Having a publicly accessible admin Kubernetes dashboard like this is \033[31mdangerous\033[0m for anything else.
+echo "  When prompted for authentication, press \"Skip\" to use the built-in admin account."
+echo "  \033[31;1mWarning:\033[0m This deployment is for research purposes only. Having a publicly accessible admin Kubernetes dashboard like this is \033[31mdangerous\033[0m for anything else."
 echo "\033[34m==================\033[0m"
 ASD
 

--- a/scripts/ck_master.sh
+++ b/scripts/ck_master.sh
@@ -81,14 +81,19 @@ sudo kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Do
 source <(kubectl completion bash)
 
 # kubectl get nodes --kubeconfig=${KUBEHOME}/admin.conf -s https://155.98.36.111:6443
+
 # Install dashboard: https://github.com/kubernetes/dashboard
-# TODO: why are we using this specific release? Would the latest get us anything?
+# v3 of kubernetes-dashboard has many software dependencies like Nginx Ingress and the set up process
+# changes drastically. v2 serves the exact same functionality with a slightly more straightforward setup,
+# so we will use the latest v2 (2.7.0) recommended YAML file as a base.
+# It has been modified to allow HTTP access and to allow admin login without credentials. More details in
+# the file itself.
 echo "Launching Kubernetes Dashboard..."
-sudo kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v1.10.1/src/deploy/recommended/kubernetes-dashboard.yaml
+sudo kubectl apply -f config/test/kubernetes-dashboard.yaml
  
 # run the proxy to make the dashboard portal accessible from outside
 echo "Running proxy at port 8080..."
-sudo kubectl proxy  --kubeconfig=${KUBEHOME}/admin.conf -p 8080 &
+sudo kubectl proxy -p 8080 --address='0.0.0.0' --accept-hosts='^*$' &
 
 # jid for json parsing.
 export GOPATH=${WORKINGDIR}/go/gopath
@@ -129,15 +134,18 @@ do
 done
 echo "All nodes joined"
 
-dashboard_endpoint=`kubectl get endpoints --all-namespaces |grep dashboard|awk '{print $3}'`
-dashboard_credential=`kubectl -n kube-system describe secret $(kubectl -n kube-system get secret | grep admin-user | awk '{print $1}') |grep token: | awk '{print $2}'`
+# Display for the end-user where the Kubernetes dashboard is, using our pcXXX hostname
+# that we can get from ipinfo.io
+echo "Kubernetes is ready at: http://$(curl ipinfo.io -s | jq -r .hostname):8080/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#/workloads?namespace=default"
 
-echo "Kubernetes is ready at: http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/#!/login"
-
-# optional address
-echo "kubernetes dashboard endpoint: $dashboard_endpoint"
-# dashboard credential
-echo "And this is the dashboard credential: $dashboard_credential"
+# Also make the link display on every SSH login too, for convenience:
+cat <<ASD >> /users/${username}/.ssh/rc
+echo "\033[34m==================\033[0m"
+echo "\033[1mCoreKube Dashboard:\033[0m http://$(curl -s ipinfo.io | jq -r .hostname):8080/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#/workloads?namespace=default"
+echo "  When prompted for authentication, press "Skip" to use the built-in admin account.
+echo "  \033[31;1mWarning:\033[0m This deployment is for research purposes only. Having a publicly accessible admin Kubernetes dashboard like this is \033[31mdangerous\033[0m for anything else.
+echo "\033[34m==================\033[0m"
+ASD
 
 #Deploy metrics server
 sudo kubectl create -f config/test/metrics-server.yaml

--- a/scripts/master.sh
+++ b/scripts/master.sh
@@ -85,16 +85,6 @@ sudo kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Do
 # use this to enable autocomplete
 source <(kubectl completion bash)
 
-# kubectl get nodes --kubeconfig=${KUBEHOME}/admin.conf -s https://155.98.36.111:6443
-# Install dashboard: https://github.com/kubernetes/dashboard
-# TODO: why are we using this specific release? Would the latest get us anything?
-echo "Launching Kubernetes Dashboard..."
-sudo kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v1.10.1/src/deploy/recommended/kubernetes-dashboard.yaml
- 
-# run the proxy to make the dashboard portal accessible from outside
-echo "Running proxy at port 8080..."
-sudo kubectl proxy  --kubeconfig=${KUBEHOME}/admin.conf -p 8080 &
-
 # jid for json parsing.
 export GOPATH=${WORKINGDIR}/go/gopath
 mkdir -p $GOPATH
@@ -126,16 +116,6 @@ do
     sleep 1
 done
 echo "All nodes joined"
-
-dashboard_endpoint=`kubectl get endpoints --all-namespaces |grep dashboard|awk '{print $3}'`
-dashboard_credential=`kubectl -n kube-system describe secret $(kubectl -n kube-system get secret | grep admin-user | awk '{print $1}') |grep token: | awk '{print $2}'`
-
-echo "Kubernetes is ready at: http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/#!/login"
-
-# optional address
-echo "kubernetes dashboard endpoint: $dashboard_endpoint"
-# dashboard credential
-echo "And this is the dashboard credential: $dashboard_credential"
 
 #Deploy metrics server
 sudo kubectl create -f config/test/metrics-server.yaml


### PR DESCRIPTION
The Kubernetes dashboard is now fully supported if this change goes in.

Changes:

- Kubernetes-dashboard is upgraded from 1.10.1 to 2.7.0 (latest version pre-3.0, which complicates installation a lot)
- Modifications have been done on the default deployment profile to allow insecure public admin logins for demo purposes (no more need to mess around with tokens/etc)
- A quick link to the dashboard is provided upon SSH-ing into the master CK node 