### PR TITLE
Add Kubernetes-Dashboard to Nervion, make URLs cleaner

### DIFF
--- a/config/test/kubernetes-dashboard.yaml
+++ b/config/test/kubernetes-dashboard.yaml
@@ -54,10 +54,13 @@ metadata:
   namespace: kubernetes-dashboard
 spec:
   ports:
+    # Modification by CoreKube team to expose HTTP port too
     - port: 80
       targetPort: 9090
+      name: tcp-80
     - port: 443
       targetPort: 8443
+      name: tcp-443
   selector:
     k8s-app: kubernetes-dashboard
 
@@ -216,18 +219,24 @@ spec:
           ports:
             - containerPort: 8443
               protocol: TCP
+            # Modification to expose HTTP port
             - containerPort: 9090
               protocol: TCP
           args:
-            - --auto-generate-certificates
             - --namespace=kubernetes-dashboard
             # Uncomment the following line to manually specify Kubernetes API server Host
             # If not specified, Dashboard will attempt to auto discover the API server and connect
             # to it. Uncomment only if the default does not work.
             # - --apiserver-host=http://my-address:port
-            # Modification by CoreKube team to allow HTTP login and using admin login
+
+            # Modification by CoreKube team to allow HTTP login and using admin login.
+            # This disables the default HTTPS 8443 port and makes kubernetes-dashboard use
+            # the default HTTP port 9090 instead.
             - --enable-insecure-login
             - --enable-skip-login
+            - --insecure-bind-address=0.0.0.0
+            - --disable-settings-authorizer
+            #- --auto-generate-certificates (uncomment to use 8443)
           volumeMounts:
             - name: kubernetes-dashboard-certs
               mountPath: /certs
@@ -236,9 +245,9 @@ spec:
               name: tmp-volume
           livenessProbe:
             httpGet:
-              scheme: HTTPS
+              scheme: HTTP # Modification by CoreKube team to use HTTP instead of HTTPS
               path: /
-              port: 8443
+              port: 9090 # Modification by CoreKube team to use 9090 instead of 8443
             initialDelaySeconds: 30
             timeoutSeconds: 30
           securityContext:

--- a/config/test/kubernetes-dashboard.yaml
+++ b/config/test/kubernetes-dashboard.yaml
@@ -54,6 +54,8 @@ metadata:
   namespace: kubernetes-dashboard
 spec:
   ports:
+    - port: 80
+      targetPort: 9090
     - port: 443
       targetPort: 8443
   selector:
@@ -213,6 +215,8 @@ spec:
           imagePullPolicy: Always
           ports:
             - containerPort: 8443
+              protocol: TCP
+            - containerPort: 9090
               protocol: TCP
           args:
             - --auto-generate-certificates

--- a/scripts/ck_5g_master.sh
+++ b/scripts/ck_5g_master.sh
@@ -134,16 +134,17 @@ do
 done
 echo "All nodes joined"
 
-# Display for the end-user where the Kubernetes dashboard is, using our pcXXX hostname
-# that we can get from ipinfo.io
+# Display for the end-user where the Kubernetes dashboard is, using our public
+# hostname that we can get from ipinfo.io - this is based on an assumption that
+# the machine would have a public hostname.
 echo "Kubernetes is ready at: http://$(curl ipinfo.io -s | jq -r .hostname):8080/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#/workloads?namespace=default"
 
 # Also make the link display on every SSH login too, for convenience:
 cat <<ASD >> /users/${username}/.ssh/rc
 echo "\033[34m==================\033[0m"
 echo "\033[1mCoreKube Dashboard:\033[0m http://$(curl -s ipinfo.io | jq -r .hostname):8080/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#/workloads?namespace=default"
-echo "  When prompted for authentication, press \"Skip\" to use the built-in admin account."
-echo "  \033[31;1mWarning:\033[0m This deployment is for research purposes only. Having a publicly accessible admin Kubernetes dashboard like this is \033[31mdangerous\033[0m for anything else."
+echo "  \033[34mWhen prompted for authentication, press \"Skip\" to use the built-in admin account."
+echo "  \033[31;1mWarning:\033[0m\033[31m This deployment is for research purposes only. Having a publicly accessible admin Kubernetes dashboard like this is dangerous for anything else.\033[0m"
 echo "\033[34m==================\033[0m"
 ASD
 

--- a/scripts/ck_5g_master.sh
+++ b/scripts/ck_5g_master.sh
@@ -91,9 +91,16 @@ source <(kubectl completion bash)
 echo "Launching Kubernetes Dashboard..."
 sudo kubectl apply -f config/test/kubernetes-dashboard.yaml
  
-# run the proxy to make the dashboard portal accessible from outside
-echo "Running proxy at port 8080..."
-sudo kubectl port-forward services/kubernetes-dashboard -n kubernetes-dashboard --address='0.0.0.0' 8080:80 &
+# run port-forward to make the dashboard portal accessible from outside
+echo "Port-forwarding port 80 of dashboard service at public port 12345..."
+sudo kubectl port-forward services/kubernetes-dashboard -n kubernetes-dashboard --address='0.0.0.0' 12345:80 &
+
+# Alternatively we could also run
+# sudo kubectl proxy -p 12345 --address='0.0.0.0' --accept-hosts='^*$' &
+# which is a bit more straightforward since you don't need to make the modifications
+# we made in the YAML file to use HTTP upstream. But, this makes all URLs quite
+# messy since you are proxying the API service and not the dashboard service itself
+# so all URLs need be prefixed with /api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/
 
 # jid for json parsing.
 export GOPATH=${WORKINGDIR}/go/gopath
@@ -140,13 +147,20 @@ echo "All nodes joined"
 echo "Kubernetes is ready at: http://$(curl ipinfo.io -s | jq -r .hostname):8080/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#/workloads?namespace=default"
 
 # Also make the link display on every SSH login too, for convenience:
+BOLD_RESET="\033[22m"
+BOLD="\033[1m"
+BLUE="\033[34m"
+RED="\033[31m"
+RESET="\033[0m"
+
 cat <<ASD >> /users/${username}/.ssh/rc
-echo "\033[34m==================\033[0m"
-echo "\033[34mThis is the CoreKube Kubernetes cluster \033[1mmaster node.\033[0m"
-echo "\033[1mCoreKube Dashboard:\033[0m http://$(curl -s ipinfo.io | jq -r .hostname):8080/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#/workloads?namespace=default"
-echo "  \033[34mWhen prompted for authentication, press \"Skip\" to use the built-in admin account."
-echo "  \033[31;1mWarning:\033[0m\033[31m This deployment is for research purposes only. Having a publicly accessible admin Kubernetes dashboard like this is dangerous for anything else.\033[0m"
-echo "\033[34m==================\033[0m"
+echo "${BLUE}==================${RESET}"
+echo "${BLUE}This is the ${BOLD}CoreKube${BOLD_RESET} Kubernetes cluster ${BOLD}master node${BOLD_RESET}."
+echo "${BOLD}CoreKube Dashboard:${RESET} http://$(curl -s ipinfo.io | jq -r .hostname):12345"
+echo ""
+echo "${BLUE}When prompted for authentication, press \"Skip\" to use the built-in admin account."
+echo "${RED}${BOLD}Warning: ${BOLD_RESET}This deployment is for research purposes only. Having a publicly accessible admin Kubernetes dashboard like this is dangerous for anything else.${RESET}"
+echo "${BLUE}==================${RESET}"
 ASD
 
 #Deploy metrics server

--- a/scripts/ck_5g_master.sh
+++ b/scripts/ck_5g_master.sh
@@ -142,6 +142,7 @@ echo "Kubernetes is ready at: http://$(curl ipinfo.io -s | jq -r .hostname):8080
 # Also make the link display on every SSH login too, for convenience:
 cat <<ASD >> /users/${username}/.ssh/rc
 echo "\033[34m==================\033[0m"
+echo "\033[34mThis is the CoreKube Kubernetes cluster \033[1mmaster node.\033[0m"
 echo "\033[1mCoreKube Dashboard:\033[0m http://$(curl -s ipinfo.io | jq -r .hostname):8080/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#/workloads?namespace=default"
 echo "  \033[34mWhen prompted for authentication, press \"Skip\" to use the built-in admin account."
 echo "  \033[31;1mWarning:\033[0m\033[31m This deployment is for research purposes only. Having a publicly accessible admin Kubernetes dashboard like this is dangerous for anything else.\033[0m"

--- a/scripts/ck_5g_master.sh
+++ b/scripts/ck_5g_master.sh
@@ -90,17 +90,18 @@ source <(kubectl completion bash)
 # the file itself.
 echo "Launching Kubernetes Dashboard..."
 sudo kubectl apply -f config/test/kubernetes-dashboard.yaml
- 
-# run port-forward to make the dashboard portal accessible from outside
-echo "Port-forwarding port 80 of dashboard service at public port 12345..."
-sudo kubectl port-forward services/kubernetes-dashboard -n kubernetes-dashboard --address='0.0.0.0' 12345:80 &
 
+# We should now port-forward the dashboard service which is at port 80 locally,
+# but we'll do that later since it'll take a few seconds to get everything ready
+# after applying the YAML file, and it's better to do other things (like doing
+# other installations) in parallel.
+#
 # Alternatively we could also run
 # sudo kubectl proxy -p 12345 --address='0.0.0.0' --accept-hosts='^*$' &
-# which is a bit more straightforward since you don't need to make the modifications
-# we made in the YAML file to use HTTP upstream. But, this makes all URLs quite
-# messy since you are proxying the API service and not the dashboard service itself
-# so all URLs need be prefixed with /api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/
+# here and now, which will make the kubernetes API service public (which can be
+# done before dashboard is ready). This is a bit more straightforward than
+# port-forwarding in terms of modifying the YAML file, but it makes URLs messy
+# since you have to prefix everything with long boilerplate.
 
 # jid for json parsing.
 export GOPATH=${WORKINGDIR}/go/gopath
@@ -120,6 +121,16 @@ tar xf helm-v3.1.0-linux-amd64.tar.gz
 sudo cp linux-amd64/helm /usr/local/bin/helm
 
 source <(helm completion bash)
+
+# run port-forward to make the dashboard portal accessible from outside
+echo "Port-forwarding port 80 of dashboard service at public port 12345..."
+# Make sure the dashboard pod is ready before port-forwarding, since otherwise
+# kubectl port-forward will fail. This adds a slight delay to the setup but it
+# should be very negligible because we've moved the waiting/port-forwarding to
+# after the helm installation above, which should give it enough time to start
+# up in the background. 
+kubectl wait -n kubernetes-dashboard --for=condition=ready pod --all
+sudo kubectl port-forward services/kubernetes-dashboard -n kubernetes-dashboard --address='0.0.0.0' 12345:80 &
 
 # Install metrics-server for HPA
 # (Old method)
@@ -144,7 +155,7 @@ echo "All nodes joined"
 # Display for the end-user where the Kubernetes dashboard is, using our public
 # hostname that we can get from ipinfo.io - this is based on an assumption that
 # the machine would have a public hostname.
-echo "Kubernetes is ready at: http://$(curl ipinfo.io -s | jq -r .hostname):8080/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#/workloads?namespace=default"
+echo "Kubernetes is ready at: http://$(curl -s ipinfo.io | jq -r .hostname):12345"
 
 # Also make the link display on every SSH login too, for convenience:
 BOLD_RESET="\033[22m"

--- a/scripts/ck_5g_master.sh
+++ b/scripts/ck_5g_master.sh
@@ -93,7 +93,7 @@ sudo kubectl apply -f config/test/kubernetes-dashboard.yaml
  
 # run the proxy to make the dashboard portal accessible from outside
 echo "Running proxy at port 8080..."
-sudo kubectl proxy -p 8080 --address='0.0.0.0' --accept-hosts='^*$' &
+sudo kubectl port-forward services/kubernetes-dashboard -n kubernetes-dashboard --address='0.0.0.0' 8080:80 &
 
 # jid for json parsing.
 export GOPATH=${WORKINGDIR}/go/gopath

--- a/scripts/ck_master.sh
+++ b/scripts/ck_master.sh
@@ -134,16 +134,17 @@ do
 done
 echo "All nodes joined"
 
-# Display for the end-user where the Kubernetes dashboard is, using our pcXXX hostname
-# that we can get from ipinfo.io
+# Display for the end-user where the Kubernetes dashboard is, using our public
+# hostname that we can get from ipinfo.io - this is based on an assumption that
+# the machine would have a public hostname.
 echo "Kubernetes is ready at: http://$(curl ipinfo.io -s | jq -r .hostname):8080/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#/workloads?namespace=default"
 
 # Also make the link display on every SSH login too, for convenience:
 cat <<ASD >> /users/${username}/.ssh/rc
 echo "\033[34m==================\033[0m"
 echo "\033[1mCoreKube Dashboard:\033[0m http://$(curl -s ipinfo.io | jq -r .hostname):8080/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#/workloads?namespace=default"
-echo "  When prompted for authentication, press \"Skip\" to use the built-in admin account."
-echo "  \033[31;1mWarning:\033[0m This deployment is for research purposes only. Having a publicly accessible admin Kubernetes dashboard like this is \033[31mdangerous\033[0m for anything else."
+echo "  \033[34mWhen prompted for authentication, press \"Skip\" to use the built-in admin account."
+echo "  \033[31;1mWarning:\033[0m\033[31m This deployment is for research purposes only. Having a publicly accessible admin Kubernetes dashboard like this is dangerous for anything else.\033[0m"
 echo "\033[34m==================\033[0m"
 ASD
 

--- a/scripts/ck_master.sh
+++ b/scripts/ck_master.sh
@@ -142,6 +142,7 @@ echo "Kubernetes is ready at: http://$(curl ipinfo.io -s | jq -r .hostname):8080
 # Also make the link display on every SSH login too, for convenience:
 cat <<ASD >> /users/${username}/.ssh/rc
 echo "\033[34m==================\033[0m"
+echo "\033[34mThis is the CoreKube Kubernetes cluster \033[1mmaster node.\033[0m"
 echo "\033[1mCoreKube Dashboard:\033[0m http://$(curl -s ipinfo.io | jq -r .hostname):8080/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#/workloads?namespace=default"
 echo "  \033[34mWhen prompted for authentication, press \"Skip\" to use the built-in admin account."
 echo "  \033[31;1mWarning:\033[0m\033[31m This deployment is for research purposes only. Having a publicly accessible admin Kubernetes dashboard like this is dangerous for anything else.\033[0m"

--- a/scripts/ck_master.sh
+++ b/scripts/ck_master.sh
@@ -90,18 +90,18 @@ source <(kubectl completion bash)
 # the file itself.
 echo "Launching Kubernetes Dashboard..."
 sudo kubectl apply -f config/test/kubernetes-dashboard.yaml
- 
-# run port-forward to make the dashboard portal accessible from outside
-echo "Port-forwarding port 80 of dashboard service at public port 12345..."
-sudo kubectl port-forward services/kubernetes-dashboard -n kubernetes-dashboard --address='0.0.0.0' 12345:80 &
 
+# We should now port-forward the dashboard service which is at port 80 locally,
+# but we'll do that later since it'll take a few seconds to get everything ready
+# after applying the YAML file, and it's better to do other things (like doing
+# other installations) in parallel.
+#
 # Alternatively we could also run
 # sudo kubectl proxy -p 12345 --address='0.0.0.0' --accept-hosts='^*$' &
-# which is a bit more straightforward since you don't need to make the modifications
-# we made in the YAML file to use HTTP upstream. But, this makes all URLs quite
-# messy since you are proxying the API service and not the dashboard service itself
-# so all URLs need be prefixed with /api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/
-
+# here and now, which will make the kubernetes API service public (which can be
+# done before dashboard is ready). This is a bit more straightforward than
+# port-forwarding in terms of modifying the YAML file, but it makes URLs messy
+# since you have to prefix everything with long boilerplate.
 
 # jid for json parsing.
 export GOPATH=${WORKINGDIR}/go/gopath
@@ -121,6 +121,16 @@ tar xf helm-v3.1.0-linux-amd64.tar.gz
 sudo cp linux-amd64/helm /usr/local/bin/helm
 
 source <(helm completion bash)
+
+# run port-forward to make the dashboard portal accessible from outside
+echo "Port-forwarding port 80 of dashboard service at public port 12345..."
+# Make sure the dashboard pod is ready before port-forwarding, since otherwise
+# kubectl port-forward will fail. This adds a slight delay to the setup but it
+# should be very negligible because we've moved the waiting/port-forwarding to
+# after the helm installation above, which should give it enough time to start
+# up in the background. 
+kubectl wait -n kubernetes-dashboard --for=condition=ready pod --all
+sudo kubectl port-forward services/kubernetes-dashboard -n kubernetes-dashboard --address='0.0.0.0' 12345:80 &
 
 # Install metrics-server for HPA
 # (Old method)
@@ -145,7 +155,7 @@ echo "All nodes joined"
 # Display for the end-user where the Kubernetes dashboard is, using our public
 # hostname that we can get from ipinfo.io - this is based on an assumption that
 # the machine would have a public hostname.
-echo "Kubernetes is ready at: http://$(curl ipinfo.io -s | jq -r .hostname):8080/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#/workloads?namespace=default"
+echo "Kubernetes is ready at: http://$(curl -s ipinfo.io | jq -r .hostname):12345"
 
 # Also make the link display on every SSH login too, for convenience:
 BOLD_RESET="\033[22m"

--- a/scripts/ck_master.sh
+++ b/scripts/ck_master.sh
@@ -91,9 +91,17 @@ source <(kubectl completion bash)
 echo "Launching Kubernetes Dashboard..."
 sudo kubectl apply -f config/test/kubernetes-dashboard.yaml
  
-# run the proxy to make the dashboard portal accessible from outside
-echo "Running proxy at port 8080..."
-sudo kubectl proxy -p 8080 --address='0.0.0.0' --accept-hosts='^*$' &
+# run port-forward to make the dashboard portal accessible from outside
+echo "Port-forwarding port 80 of dashboard service at public port 12345..."
+sudo kubectl port-forward services/kubernetes-dashboard -n kubernetes-dashboard --address='0.0.0.0' 12345:80 &
+
+# Alternatively we could also run
+# sudo kubectl proxy -p 12345 --address='0.0.0.0' --accept-hosts='^*$' &
+# which is a bit more straightforward since you don't need to make the modifications
+# we made in the YAML file to use HTTP upstream. But, this makes all URLs quite
+# messy since you are proxying the API service and not the dashboard service itself
+# so all URLs need be prefixed with /api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/
+
 
 # jid for json parsing.
 export GOPATH=${WORKINGDIR}/go/gopath
@@ -140,13 +148,20 @@ echo "All nodes joined"
 echo "Kubernetes is ready at: http://$(curl ipinfo.io -s | jq -r .hostname):8080/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#/workloads?namespace=default"
 
 # Also make the link display on every SSH login too, for convenience:
+BOLD_RESET="\033[22m"
+BOLD="\033[1m"
+BLUE="\033[34m"
+RED="\033[31m"
+RESET="\033[0m"
+
 cat <<ASD >> /users/${username}/.ssh/rc
-echo "\033[34m==================\033[0m"
-echo "\033[34mThis is the CoreKube Kubernetes cluster \033[1mmaster node.\033[0m"
-echo "\033[1mCoreKube Dashboard:\033[0m http://$(curl -s ipinfo.io | jq -r .hostname):8080/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#/workloads?namespace=default"
-echo "  \033[34mWhen prompted for authentication, press \"Skip\" to use the built-in admin account."
-echo "  \033[31;1mWarning:\033[0m\033[31m This deployment is for research purposes only. Having a publicly accessible admin Kubernetes dashboard like this is dangerous for anything else.\033[0m"
-echo "\033[34m==================\033[0m"
+echo "${BLUE}==================${RESET}"
+echo "${BLUE}This is the ${BOLD}CoreKube${BOLD_RESET} Kubernetes cluster ${BOLD}master node${BOLD_RESET}."
+echo "${BOLD}CoreKube Dashboard:${RESET} http://$(curl -s ipinfo.io | jq -r .hostname):12345"
+echo ""
+echo "${BLUE}When prompted for authentication, press \"Skip\" to use the built-in admin account."
+echo "${RED}${BOLD}Warning: ${BOLD_RESET}This deployment is for research purposes only. Having a publicly accessible admin Kubernetes dashboard like this is dangerous for anything else.${RESET}"
+echo "${BLUE}==================${RESET}"
 ASD
 
 #Deploy metrics server

--- a/scripts/master.sh
+++ b/scripts/master.sh
@@ -139,8 +139,8 @@ echo "Kubernetes is ready at: http://$(curl ipinfo.io -s | jq -r .hostname):8080
 cat <<ASD >> /users/${username}/.ssh/rc
 echo "\033[34m==================\033[0m"
 echo "\033[1mCoreKube Dashboard:\033[0m http://$(curl -s ipinfo.io | jq -r .hostname):8080/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#/workloads?namespace=default"
-echo "  When prompted for authentication, press \"Skip\" to use the built-in admin account."
-echo "  \033[31;1mWarning:\033[0m This deployment is for research purposes only. Having a publicly accessible admin Kubernetes dashboard like this is \033[31mdangerous\033[0m for anything else."
+echo "  \033[34mWhen prompted for authentication, press \"Skip\" to use the built-in admin account."
+echo "  \033[31;1mWarning:\033[0m\033[31m This deployment is for research purposes only. Having a publicly accessible admin Kubernetes dashboard like this is dangerous for anything else.\033[0m"
 echo "\033[34m==================\033[0m"
 ASD
 

--- a/scripts/master.sh
+++ b/scripts/master.sh
@@ -137,11 +137,12 @@ echo "Kubernetes is ready at: http://$(curl ipinfo.io -s | jq -r .hostname):8080
 
 # Also make the link display on every SSH login too, for convenience:
 cat <<ASD >> /users/${username}/.ssh/rc
-echo "\033[34m==================\033[0m"
-echo "\033[1mCoreKube Dashboard:\033[0m http://$(curl -s ipinfo.io | jq -r .hostname):8080/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#/workloads?namespace=default"
+echo "\033[32m==================\033[0m"
+echo "\033[32mThis is the Nervion Kubernetes cluster \033[1mmaster node.\033[0m"
+echo "\033[1mNervion Kubernetes Dashboard:\033[0m http://$(curl -s ipinfo.io | jq -r .hostname):8080/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#/workloads?namespace=default"
 echo "  \033[34mWhen prompted for authentication, press \"Skip\" to use the built-in admin account."
 echo "  \033[31;1mWarning:\033[0m\033[31m This deployment is for research purposes only. Having a publicly accessible admin Kubernetes dashboard like this is dangerous for anything else.\033[0m"
-echo "\033[34m==================\033[0m"
+echo "\033[32m==================\033[0m"
 ASD
 
 #Deploy metrics server

--- a/scripts/master.sh
+++ b/scripts/master.sh
@@ -85,6 +85,19 @@ sudo kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Do
 # use this to enable autocomplete
 source <(kubectl completion bash)
 
+# Install dashboard: https://github.com/kubernetes/dashboard
+# v3 of kubernetes-dashboard has many software dependencies like Nginx Ingress and the set up process
+# changes drastically. v2 serves the exact same functionality with a slightly more straightforward setup,
+# so we will use the latest v2 (2.7.0) recommended YAML file as a base.
+# It has been modified to allow HTTP access and to allow admin login without credentials. More details in
+# the file itself.
+echo "Launching Kubernetes Dashboard..."
+sudo kubectl apply -f config/test/kubernetes-dashboard.yaml
+ 
+# run the proxy to make the dashboard portal accessible from outside
+echo "Running proxy at port 8080..."
+sudo kubectl proxy -p 8080 --address='0.0.0.0' --accept-hosts='^*$' &
+
 # jid for json parsing.
 export GOPATH=${WORKINGDIR}/go/gopath
 mkdir -p $GOPATH
@@ -116,6 +129,20 @@ do
     sleep 1
 done
 echo "All nodes joined"
+
+# Display for the end-user where the Kubernetes dashboard is, using our public
+# hostname that we can get from ipinfo.io - this is based on an assumption that
+# the machine would have a public hostname.
+echo "Kubernetes is ready at: http://$(curl ipinfo.io -s | jq -r .hostname):8080/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#/workloads?namespace=default"
+
+# Also make the link display on every SSH login too, for convenience:
+cat <<ASD >> /users/${username}/.ssh/rc
+echo "\033[34m==================\033[0m"
+echo "\033[1mCoreKube Dashboard:\033[0m http://$(curl -s ipinfo.io | jq -r .hostname):8080/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#/workloads?namespace=default"
+echo "  When prompted for authentication, press \"Skip\" to use the built-in admin account."
+echo "  \033[31;1mWarning:\033[0m This deployment is for research purposes only. Having a publicly accessible admin Kubernetes dashboard like this is \033[31mdangerous\033[0m for anything else."
+echo "\033[34m==================\033[0m"
+ASD
 
 #Deploy metrics server
 sudo kubectl create -f config/test/metrics-server.yaml


### PR DESCRIPTION
Changes:
- Kubernetes Dashboard is now available on Nervion master node too, not just CK master node
- Dashboard URLs now much cleaner, it's `<hostname>:12345` on both CK and nervion