### PR TITLE
Fix broken SCP and VM hostnames

### DIFF
--- a/scripts/ck_5g_master.sh
+++ b/scripts/ck_5g_master.sh
@@ -153,9 +153,8 @@ done
 echo "All nodes joined"
 
 # Display for the end-user where the Kubernetes dashboard is, using our public
-# hostname that we can get from ipinfo.io - this is based on an assumption that
-# the machine would have a public hostname.
-echo "Kubernetes is ready at: http://$(curl -s ipinfo.io | jq -r .hostname):12345"
+# hostname
+echo "Kubernetes is ready at: http://$(hostname --fqdn):12345"
 
 # Also make the link display on every SSH login too, for convenience:
 BOLD_RESET="\033[22m"
@@ -167,7 +166,7 @@ RESET="\033[0m"
 cat <<ASD >> /users/${username}/.ssh/rc
 echo "${BLUE}==================${RESET}"
 echo "${BLUE}This is the ${BOLD}CoreKube${BOLD_RESET} Kubernetes cluster ${BOLD}master node${BOLD_RESET}."
-echo "${BOLD}CoreKube Dashboard:${RESET} http://$(curl -s ipinfo.io | jq -r .hostname):12345"
+echo "${BOLD}CoreKube Dashboard:${RESET} http://$(hostname --fqdn):12345"
 echo ""
 echo "${BLUE}When prompted for authentication, press \"Skip\" to use the built-in admin account."
 echo "${RED}${BOLD}Warning: ${BOLD_RESET}This deployment is for research purposes only. Having a publicly accessible admin Kubernetes dashboard like this is dangerous for anything else.${RESET}"

--- a/scripts/ck_5g_master.sh
+++ b/scripts/ck_5g_master.sh
@@ -164,6 +164,7 @@ RED="\033[31m"
 RESET="\033[0m"
 
 cat <<ASD >> /users/${username}/.ssh/rc
+test -z $SSH_TTY && return # Don't run when not-interactive like SCP
 echo "${BLUE}==================${RESET}"
 echo "${BLUE}This is the ${BOLD}CoreKube${BOLD_RESET} Kubernetes cluster ${BOLD}master node${BOLD_RESET}."
 echo "${BOLD}CoreKube Dashboard:${RESET} http://$(hostname --fqdn):12345"

--- a/scripts/ck_master.sh
+++ b/scripts/ck_master.sh
@@ -153,9 +153,8 @@ done
 echo "All nodes joined"
 
 # Display for the end-user where the Kubernetes dashboard is, using our public
-# hostname that we can get from ipinfo.io - this is based on an assumption that
-# the machine would have a public hostname.
-echo "Kubernetes is ready at: http://$(curl -s ipinfo.io | jq -r .hostname):12345"
+# hostname
+echo "Kubernetes is ready at: http://$(hostname --fqdn):12345"
 
 # Also make the link display on every SSH login too, for convenience:
 BOLD_RESET="\033[22m"
@@ -167,7 +166,7 @@ RESET="\033[0m"
 cat <<ASD >> /users/${username}/.ssh/rc
 echo "${BLUE}==================${RESET}"
 echo "${BLUE}This is the ${BOLD}CoreKube${BOLD_RESET} Kubernetes cluster ${BOLD}master node${BOLD_RESET}."
-echo "${BOLD}CoreKube Dashboard:${RESET} http://$(curl -s ipinfo.io | jq -r .hostname):12345"
+echo "${BOLD}CoreKube Dashboard:${RESET} http://$(hostname --fqdn):12345"
 echo ""
 echo "${BLUE}When prompted for authentication, press \"Skip\" to use the built-in admin account."
 echo "${RED}${BOLD}Warning: ${BOLD_RESET}This deployment is for research purposes only. Having a publicly accessible admin Kubernetes dashboard like this is dangerous for anything else.${RESET}"

--- a/scripts/ck_master.sh
+++ b/scripts/ck_master.sh
@@ -164,6 +164,7 @@ RED="\033[31m"
 RESET="\033[0m"
 
 cat <<ASD >> /users/${username}/.ssh/rc
+test -z $SSH_TTY && return # Don't run when not-interactive like SCP
 echo "${BLUE}==================${RESET}"
 echo "${BLUE}This is the ${BOLD}CoreKube${BOLD_RESET} Kubernetes cluster ${BOLD}master node${BOLD_RESET}."
 echo "${BOLD}CoreKube Dashboard:${RESET} http://$(hostname --fqdn):12345"

--- a/scripts/master.sh
+++ b/scripts/master.sh
@@ -161,6 +161,7 @@ RED="\033[31m"
 RESET="\033[0m"
 
 cat <<ASD >> /users/${username}/.ssh/rc
+test -z $SSH_TTY && return # Don't run when not-interactive like SCP
 echo "${GREEN}==================${RESET}"
 echo "${GREEN}This is the ${BOLD}Nervion${BOLD_RESET} Kubernetes cluster ${BOLD}master node${BOLD_RESET}."
 echo "${BOLD}Nervion Kubernetes Dashboard:${RESET} http://$(hostname --fqdn):12345"

--- a/scripts/master.sh
+++ b/scripts/master.sh
@@ -149,9 +149,8 @@ done
 echo "All nodes joined"
 
 # Display for the end-user where the Kubernetes dashboard is, using our public
-# hostname that we can get from ipinfo.io - this is based on an assumption that
-# the machine would have a public hostname.
-echo "Kubernetes is ready at: http://$(curl -s ipinfo.io | jq -r .hostname):12345"
+# hostname
+echo "Kubernetes is ready at: http://$(hostname --fqdn):12345"
 
 # Also make the link display on every SSH login too, for convenience:
 BOLD_RESET="\033[22m"
@@ -164,7 +163,7 @@ RESET="\033[0m"
 cat <<ASD >> /users/${username}/.ssh/rc
 echo "${GREEN}==================${RESET}"
 echo "${GREEN}This is the ${BOLD}Nervion${BOLD_RESET} Kubernetes cluster ${BOLD}master node${BOLD_RESET}."
-echo "${BOLD}Nervion Kubernetes Dashboard:${RESET} http://$(curl -s ipinfo.io | jq -r .hostname):12345"
+echo "${BOLD}Nervion Kubernetes Dashboard:${RESET} http://$(hostname --fqdn):12345"
 echo ""
 echo "${BLUE}When prompted for authentication, press \"Skip\" to use the built-in admin account."
 echo "${RED}${BOLD}Warning: ${BOLD_RESET}This deployment is for research purposes only. Having a publicly accessible admin Kubernetes dashboard like this is dangerous for anything else.${RESET}"

--- a/scripts/master.sh
+++ b/scripts/master.sh
@@ -167,6 +167,8 @@ echo "${BOLD}Nervion Kubernetes Dashboard:${RESET} http://$(hostname --fqdn):123
 echo ""
 echo "${BLUE}When prompted for authentication, press \"Skip\" to use the built-in admin account."
 echo "${RED}${BOLD}Warning: ${BOLD_RESET}This deployment is for research purposes only. Having a publicly accessible admin Kubernetes dashboard like this is dangerous for anything else.${RESET}"
+echo ""
+echo "${GREEN}${BOLD}Nervion Controller UI:${RESET} http://$(hostname --fqdn):34567"
 echo "${GREEN}==================${RESET}"
 ASD
 


### PR DESCRIPTION
Changes:
- SCP was broken by the sshrc welcome message, since SCP uses stdout to transmit files and it interferes. This is now fixed.
- VMs had wrong hostnames in the welcome messages for the dashboard, now this is fixed.