### PR TITLE
Fix unescaped SSH_TTY variable when echoing to file

### DIFF
--- a/scripts/ck_5g_master.sh
+++ b/scripts/ck_5g_master.sh
@@ -164,7 +164,7 @@ RED="\033[31m"
 RESET="\033[0m"
 
 cat <<ASD >> /users/${username}/.ssh/rc
-test -z $SSH_TTY && return # Don't run when not-interactive like SCP
+test -z \$SSH_TTY && return # Don't run when not-interactive like SCP
 echo "${BLUE}==================${RESET}"
 echo "${BLUE}This is the ${BOLD}CoreKube${BOLD_RESET} Kubernetes cluster ${BOLD}master node${BOLD_RESET}."
 echo "${BOLD}CoreKube Dashboard:${RESET} http://$(hostname --fqdn):12345"

--- a/scripts/ck_master.sh
+++ b/scripts/ck_master.sh
@@ -164,7 +164,7 @@ RED="\033[31m"
 RESET="\033[0m"
 
 cat <<ASD >> /users/${username}/.ssh/rc
-test -z $SSH_TTY && return # Don't run when not-interactive like SCP
+test -z \$SSH_TTY && return # Don't run when not-interactive like SCP
 echo "${BLUE}==================${RESET}"
 echo "${BLUE}This is the ${BOLD}CoreKube${BOLD_RESET} Kubernetes cluster ${BOLD}master node${BOLD_RESET}."
 echo "${BOLD}CoreKube Dashboard:${RESET} http://$(hostname --fqdn):12345"

--- a/scripts/master.sh
+++ b/scripts/master.sh
@@ -161,7 +161,7 @@ RED="\033[31m"
 RESET="\033[0m"
 
 cat <<ASD >> /users/${username}/.ssh/rc
-test -z $SSH_TTY && return # Don't run when not-interactive like SCP
+test -z \$SSH_TTY && return # Don't run when not-interactive like SCP
 echo "${GREEN}==================${RESET}"
 echo "${GREEN}This is the ${BOLD}Nervion${BOLD_RESET} Kubernetes cluster ${BOLD}master node${BOLD_RESET}."
 echo "${BOLD}Nervion Kubernetes Dashboard:${RESET} http://$(hostname --fqdn):12345"


### PR DESCRIPTION
$SSH_TTY was evaluated while echoing to file instead of writing it verbatim, which was desired. This commit fixes it by escaping the dollar signs.