### PR TITLE
temp: Change ran_controller to fix ImagePullBackOff and add scaling

### DIFF
--- a/config/deployment.yaml
+++ b/config/deployment.yaml
@@ -46,7 +46,7 @@ spec:
     spec:
       containers:
       - name: ran-emulator
-        image: j0lama/ran_controller:latest
+        image: yutotakano/ran_controller_test:202308301735
         env:
         - name: PYTHONUNBUFFERED
           value: "0"


### PR DESCRIPTION
**Merge after #10**

Hi Jon,

This is a temporary fix for MobiCom that changes the ran_controller image to one that has the ImagePullBackOff issue fixed and optional incremental scaling implemented (default is the same behaviour). 

The image contains the changes from https://github.com/j0lama/ran_emulator/pull/3.