### PR TITLE
[replaced] Implement Grafana monitoring

### DIFF
--- a/config/deployment.yaml
+++ b/config/deployment.yaml
@@ -46,7 +46,7 @@ spec:
     spec:
       containers:
       - name: ran-emulator
-        image: j0lama/ran_controller:latest
+        image: yutotakano/ran_controller_test:202308301735
         env:
         - name: PYTHONUNBUFFERED
           value: "0"

--- a/config/test/5G/deployment.yaml
+++ b/config/test/5G/deployment.yaml
@@ -148,7 +148,7 @@ spec:
             fieldRef:
               fieldPath: status.podIP
       - name: corekube-core-monitor
-        image: yutotakano/corekube-core-monitor:202308291619
+        image: yutotakano/corekube-core-monitor:202308311633
         command:
         - python3
         - core-monitor.py

--- a/config/test/5G/deployment.yaml
+++ b/config/test/5G/deployment.yaml
@@ -204,9 +204,9 @@ roleRef:
 apiVersion: v1
 kind: Service
 metadata:
-  name: corekube-core-monitor
+  name: corekube-metrics-export-service
   labels:
-    app: corekube-core-monitor
+    app: corekube-metrics-export-service
 spec:
   type: ClusterIP
   selector:

--- a/config/test/5G/deployment.yaml
+++ b/config/test/5G/deployment.yaml
@@ -148,7 +148,7 @@ spec:
             fieldRef:
               fieldPath: status.podIP
       - name: corekube-core-monitor
-        image: yutotakano/corekube-core-monitor:202308251623
+        image: yutotakano/corekube-core-monitor:202308291619
         command:
         - python3
         - core-monitor.py

--- a/config/test/5G/deployment.yaml
+++ b/config/test/5G/deployment.yaml
@@ -148,7 +148,7 @@ spec:
             fieldRef:
               fieldPath: status.podIP
       - name: corekube-core-monitor
-        image: yutotakano/corekube-core-monitor:202307311714
+        image: yutotakano/corekube-core-monitor:202308251623
         command:
         - python3
         - core-monitor.py

--- a/config/test/5G/deployment.yaml
+++ b/config/test/5G/deployment.yaml
@@ -148,7 +148,7 @@ spec:
             fieldRef:
               fieldPath: status.podIP
       - name: corekube-core-monitor
-        image: yutotakano/corekube-core-monitor:202308311633
+        image: yutotakano/corekube-core-monitor:202309011548
         command:
         - python3
         - core-monitor.py

--- a/config/test/5G/deployment.yaml
+++ b/config/test/5G/deployment.yaml
@@ -133,6 +133,7 @@ spec:
       labels:
         app: corekube-frontend
     spec:
+      serviceAccountName: corekube-core-sa
       containers:
       - name: corekube-frontend
         image: andrewferguson/corekube-frontend:latest
@@ -146,3 +147,71 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+      - name: corekube-core-monitor
+        image: yutotakano/corekube-core-monitor:202307311714
+        command:
+        - python3
+        - core-monitor.py
+        - '5050'
+        - '1'
+        ports:
+        - containerPort: 5050
+        securityContext:
+          privileged: true # Required to access the Kubernetes API
+
+
+---
+
+# Create a Service Account to be used by the Core Monitor when querying the Kubernetes API
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: corekube-core-sa
+
+---
+
+# Create a ClusterRole that has the capabilities to get/list the pods/nodes in the API
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: corekube-core-cr
+rules:
+- apiGroups: ["metrics.k8s.io"]
+  resources: ["pods", "nodes"]
+  verbs: ["get", "list", "watch"]
+
+---
+
+# Bind the above ClusterRole to the Service Account
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: corekube-core-crb
+subjects:
+- kind: ServiceAccount
+  name: corekube-core-sa
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: corekube-core-cr
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+# Expose the corekube-core-monitor container's port 5050 (within the
+# corekube-frontend pod) as a service that can be accessed from within the
+# cluster network (and from Prometheus)
+apiVersion: v1
+kind: Service
+metadata:
+  name: corekube-core-monitor
+  labels:
+    app: corekube-core-monitor
+spec:
+  type: ClusterIP
+  selector:
+    app: corekube-frontend # The selector for the pod containing core-monitor
+  ports:
+  - port: 5050
+    targetPort: 5050
+    protocol: TCP

--- a/config/test/dashboards/main-dashboard.json
+++ b/config/test/dashboards/main-dashboard.json
@@ -86,7 +86,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 10,
         "w": 12,
         "x": 0,
         "y": 0
@@ -189,7 +189,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 10,
         "w": 12,
         "x": 12,
         "y": 0
@@ -255,9 +255,6 @@
             },
             "insertNulls": false,
             "lineInterpolation": "linear",
-            "lineStyle": {
-              "fill": "solid"
-            },
             "lineWidth": 2,
             "pointSize": 5,
             "scaleDistribution": {
@@ -273,7 +270,6 @@
               "mode": "off"
             }
           },
-          "decimals": 0,
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -292,10 +288,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 6,
         "w": 12,
         "x": 0,
-        "y": 8
+        "y": 10
       },
       "id": 4,
       "options": {
@@ -303,7 +299,7 @@
           "calcs": [],
           "displayMode": "list",
           "placement": "bottom",
-          "showLegend": false
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -324,7 +320,7 @@
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
-          "refId": "Number of Workers",
+          "refId": "A",
           "useBackend": false
         }
       ],
@@ -345,7 +341,110 @@
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "Latency (s)",
+            "axisLabel": "Memory",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 4,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 10
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus-datasource-1"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "coremon_mem_usage{namespace=\"default\", container_name!=\"corekube-core-monitor\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{pod_name}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "CoreKube Memory Usage (Stacked)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus-datasource-1"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Latency",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -390,15 +489,15 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "ms"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 8
+        "x": 0,
+        "y": 16
       },
       "id": 3,
       "options": {
@@ -437,6 +536,7 @@
             "uid": "prometheus-datasource-1"
           },
           "editorMode": "code",
+          "exemplar": false,
           "expr": "avg (coremon_latency)",
           "hide": false,
           "instant": false,
@@ -445,12 +545,12 @@
           "refId": "Average Latency"
         }
       ],
-      "title": "CoreKube Core Latency",
+      "title": "CoreKube Latency",
       "transformations": [],
       "type": "timeseries"
     }
   ],
-  "refresh": "",
+  "refresh": "5s",
   "schemaVersion": 38,
   "style": "dark",
   "tags": [],

--- a/config/test/dashboards/main-dashboard.json
+++ b/config/test/dashboards/main-dashboard.json
@@ -241,7 +241,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "light-purple",
                 "value": null
               }
             ]
@@ -302,7 +302,8 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "fixedColor": "light-purple",
+            "mode": "fixed"
           },
           "custom": {
             "axisCenteredZero": false,
@@ -503,7 +504,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "semi-dark-purple",
+                "color": "green",
                 "value": null
               },
               {
@@ -572,7 +573,7 @@
         "defaults": {
           "color": {
             "fixedColor": "semi-dark-purple",
-            "mode": "fixed"
+            "mode": "palette-classic"
           },
           "custom": {
             "axisCenteredZero": false,

--- a/config/test/dashboards/main-dashboard.json
+++ b/config/test/dashboards/main-dashboard.json
@@ -17,7 +17,7 @@
   },
   "editable": true,
   "fiscalYearStartMonth": 0,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": 1,
   "links": [],
   "liveNow": false,
@@ -86,7 +86,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 10,
+        "h": 8,
         "w": 12,
         "x": 0,
         "y": 0
@@ -100,7 +100,7 @@
           "showLegend": true
         },
         "tooltip": {
-          "mode": "single",
+          "mode": "multi",
           "sort": "none"
         }
       },
@@ -189,12 +189,218 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 10,
+        "h": 8,
         "w": 12,
         "x": 12,
         "y": 0
       },
       "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus-datasource-1"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "coremon_mem_usage{namespace=\"default\", container_name!=\"corekube-core-monitor\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{pod_name}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "CoreKube Memory Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus-datasource-1"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Cores",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "si: cores"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus-datasource-1"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "coremon_cpu_usage{namespace=\"default\", container_name!=\"corekube-core-monitor\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{pod_name}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "CoreKube CPU Usage (Stacked)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus-datasource-1"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Memory",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 19,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 5,
       "options": {
         "legend": {
           "calcs": [],
@@ -225,8 +431,79 @@
           "useBackend": false
         }
       ],
-      "title": "CoreKube Memory Usage",
+      "title": "CoreKube Memory Usage (Stacked)",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus-datasource-1"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 2,
+        "x": 0,
+        "y": 17
+      },
+      "id": 8,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus-datasource-1"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "count(coremon_cpu_usage{namespace=\"default\", container_name=\"corekube-worker\"})",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "CK Workers",
+      "type": "stat"
     },
     {
       "datasource": {
@@ -288,10 +565,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
-        "w": 12,
-        "x": 0,
-        "y": 10
+        "h": 7,
+        "w": 5,
+        "x": 2,
+        "y": 17
       },
       "id": 4,
       "options": {
@@ -332,7 +609,6 @@
         "type": "prometheus",
         "uid": "prometheus-datasource-1"
       },
-      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -341,11 +617,11 @@
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "Memory",
+            "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 4,
+            "fillOpacity": 0,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -354,10 +630,7 @@
             },
             "insertNulls": false,
             "lineInterpolation": "linear",
-            "lineStyle": {
-              "fill": "solid"
-            },
-            "lineWidth": 2,
+            "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
@@ -366,7 +639,7 @@
             "spanNulls": false,
             "stacking": {
               "group": "A",
-              "mode": "normal"
+              "mode": "none"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -385,18 +658,17 @@
                 "value": 80
               }
             ]
-          },
-          "unit": "decbytes"
+          }
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 10,
-        "w": 12,
-        "x": 12,
-        "y": 10
+        "h": 7,
+        "w": 5,
+        "x": 7,
+        "y": 17
       },
-      "id": 5,
+      "id": 6,
       "options": {
         "legend": {
           "calcs": [],
@@ -417,18 +689,89 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "coremon_mem_usage{namespace=\"default\", container_name!=\"corekube-core-monitor\"}",
+          "expr": "coremon_ue_count_last_5_seconds",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "{{pod_name}}",
+          "legendFormat": "__auto",
           "range": true,
           "refId": "A",
           "useBackend": false
         }
       ],
-      "title": "CoreKube Memory Usage (Stacked)",
+      "title": "Number of Connected UEs",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus-datasource-1"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 2,
+        "x": 12,
+        "y": 17
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus-datasource-1"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "avg (coremon_latency)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "Average Latency"
+        }
+      ],
+      "title": "Avg Latency",
+      "transformations": [],
+      "type": "stat"
     },
     {
       "datasource": {
@@ -489,15 +832,15 @@
               }
             ]
           },
-          "unit": "ms"
+          "unit": "s"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 16
+        "h": 7,
+        "w": 10,
+        "x": 14,
+        "y": 17
       },
       "id": 3,
       "options": {
@@ -548,6 +891,76 @@
       "title": "CoreKube Latency",
       "transformations": [],
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus-datasource-1"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 0,
+        "y": 20
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus-datasource-1"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "coremon_ue_count_last_5_seconds",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "UEs",
+      "type": "stat"
     }
   ],
   "refresh": "5s",
@@ -558,13 +971,13 @@
     "list": []
   },
   "time": {
-    "from": "now-15m",
+    "from": "now-10m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "CoreKube Dashboard",
   "uid": "be3d8ddb-7d64-4ac5-b27c-3b771e5ec831",
-  "version": 1,
+  "version": 7,
   "weekStart": ""
 }

--- a/config/test/dashboards/main-dashboard.json
+++ b/config/test/dashboards/main-dashboard.json
@@ -445,10 +445,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           },
@@ -890,10 +886,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           },
@@ -1162,6 +1154,6 @@
   "timezone": "",
   "title": "CoreKube Dashboard",
   "uid": "be3d8ddb-7d64-4ac5-b27c-3b771e5ec831",
-  "version": 9,
+  "version": 2,
   "weekStart": ""
 }

--- a/config/test/dashboards/main-dashboard.json
+++ b/config/test/dashboards/main-dashboard.json
@@ -40,208 +40,6 @@
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineStyle": {
-              "fill": "solid"
-            },
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "si: cores"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 0
-      },
-      "id": 1,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus-datasource-1"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "expr": "label_replace(label_replace(label_replace(coremon_cpu_usage{namespace=\"default\", container_name!=\"corekube-core-monitor\"}, \"name\", \"Worker $1\", \"pod_name\", \"corekube-worker-[^-]+-(.*)\"), \"name\", \"Frontend\", \"pod_name\", \"corekube-frontend-[^-]+-(.*)\"), \"name\", \"DB\", \"pod_name\", \"corekube-db-[^-]+-(.*)\")",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "{{name}}",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "CoreKube CPU Usage",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus-datasource-1"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "Memory",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineStyle": {
-              "fill": "solid"
-            },
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "decbytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 0
-      },
-      "id": 2,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus-datasource-1"
-          },
-          "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "label_replace(label_replace(label_replace(coremon_mem_usage{namespace=\"default\", container_name!=\"corekube-core-monitor\"}, \"name\", \"Worker $1\", \"pod_name\", \"corekube-worker-[^-]+-(.*)\"), \"name\", \"Frontend\", \"pod_name\", \"corekube-frontend-[^-]+-(.*)\"), \"name\", \"DB\", \"pod_name\", \"corekube-db-[^-]+-(.*)\")",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "{{name}}",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "CoreKube Memory Usage",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus-datasource-1"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "Cores",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
             "fillOpacity": 25,
             "gradientMode": "none",
             "hideFrom": {
@@ -291,7 +89,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 8
+        "y": 0
       },
       "id": 10,
       "options": {
@@ -299,7 +97,7 @@
           "calcs": [],
           "displayMode": "list",
           "placement": "bottom",
-          "showLegend": true
+          "showLegend": false
         },
         "tooltip": {
           "mode": "single",
@@ -394,7 +192,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 8
+        "y": 0
       },
       "id": 5,
       "options": {
@@ -402,7 +200,7 @@
           "calcs": [],
           "displayMode": "list",
           "placement": "bottom",
-          "showLegend": true
+          "showLegend": false
         },
         "tooltip": {
           "mode": "single",
@@ -456,7 +254,7 @@
         "h": 3,
         "w": 2,
         "x": 0,
-        "y": 17
+        "y": 9
       },
       "id": 8,
       "options": {
@@ -473,7 +271,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "10.1.0",
+      "pluginVersion": "10.1.2",
       "targets": [
         {
           "datasource": {
@@ -558,7 +356,7 @@
         "h": 6,
         "w": 5,
         "x": 2,
-        "y": 17
+        "y": 9
       },
       "id": 4,
       "options": {
@@ -602,7 +400,8 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "fixedColor": "dark-yellow",
+            "mode": "fixed"
           },
           "custom": {
             "axisCenteredZero": false,
@@ -640,12 +439,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "dark-yellow",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           }
@@ -656,7 +451,7 @@
         "h": 6,
         "w": 5,
         "x": 7,
-        "y": 17
+        "y": 9
       },
       "id": 6,
       "options": {
@@ -708,7 +503,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "semi-dark-purple",
                 "value": null
               },
               {
@@ -729,7 +524,7 @@
         "h": 6,
         "w": 2,
         "x": 12,
-        "y": 17
+        "y": 9
       },
       "id": 9,
       "options": {
@@ -746,7 +541,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "10.1.0",
+      "pluginVersion": "10.1.2",
       "targets": [
         {
           "datasource": {
@@ -776,7 +571,8 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "fixedColor": "semi-dark-purple",
+            "mode": "fixed"
           },
           "custom": {
             "axisCenteredZero": false,
@@ -819,10 +615,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           },
@@ -834,7 +626,7 @@
         "h": 6,
         "w": 10,
         "x": 14,
-        "y": 17
+        "y": 9
       },
       "id": 3,
       "options": {
@@ -884,7 +676,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "dark-yellow",
                 "value": null
               }
             ]
@@ -897,7 +689,7 @@
         "h": 3,
         "w": 2,
         "x": 0,
-        "y": 20
+        "y": 12
       },
       "id": 7,
       "options": {
@@ -914,7 +706,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "10.1.0",
+      "pluginVersion": "10.1.2",
       "targets": [
         {
           "datasource": {
@@ -956,13 +748,44 @@
           },
           "unit": "pps"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Downlink"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Uplink"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,
         "w": 4,
         "x": 0,
-        "y": 23
+        "y": 15
       },
       "id": 12,
       "options": {
@@ -979,24 +802,8 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "10.1.0",
+      "pluginVersion": "10.1.2",
       "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus-datasource-1"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "expr": "label_replace(rate(coremon_downlink_packets_total[$__rate_interval]), \"name\", \"Downlink\", \"\", \"\")",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "{{name}}",
-          "range": true,
-          "refId": "Downlink Packet Rate",
-          "useBackend": false
-        },
         {
           "datasource": {
             "type": "prometheus",
@@ -1012,6 +819,22 @@
           "legendFormat": "{{name}}",
           "range": true,
           "refId": "Uplink Packet Rate",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus-datasource-1"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "label_replace(rate(coremon_downlink_packets_total[$__rate_interval]), \"name\", \"Downlink\", \"\", \"\")",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{name}}",
+          "range": true,
+          "refId": "Downlink Packet Rate",
           "useBackend": false
         }
       ],
@@ -1077,13 +900,44 @@
           },
           "unit": "pps"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Uplink"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Downlink"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,
         "w": 20,
         "x": 4,
-        "y": 23
+        "y": 15
       },
       "id": 11,
       "options": {

--- a/config/test/dashboards/main-dashboard.json
+++ b/config/test/dashboards/main-dashboard.json
@@ -111,12 +111,12 @@
             "uid": "prometheus-datasource-1"
           },
           "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "coremon_cpu_usage{namespace=\"default\", container_name!=\"corekube-core-monitor\"}",
+          "editorMode": "code",
+          "expr": "label_replace(label_replace(label_replace(coremon_cpu_usage{namespace=\"default\", container_name!=\"corekube-core-monitor\"}, \"name\", \"Worker $1\", \"pod_name\", \"corekube-worker-[^-]+-(.*)\"), \"name\", \"Frontend\", \"pod_name\", \"corekube-frontend-[^-]+-(.*)\"), \"name\", \"DB\", \"pod_name\", \"corekube-db-[^-]+-(.*)\")",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "{{pod_name}}",
+          "legendFormat": "{{name}}",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -215,11 +215,11 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "coremon_mem_usage{namespace=\"default\", container_name!=\"corekube-core-monitor\"}",
+          "expr": "label_replace(label_replace(label_replace(coremon_mem_usage{namespace=\"default\", container_name!=\"corekube-core-monitor\"}, \"name\", \"Worker $1\", \"pod_name\", \"corekube-worker-[^-]+-(.*)\"), \"name\", \"Frontend\", \"pod_name\", \"corekube-frontend-[^-]+-(.*)\"), \"name\", \"DB\", \"pod_name\", \"corekube-db-[^-]+-(.*)\")",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "{{pod_name}}",
+          "legendFormat": "{{name}}",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -317,12 +317,12 @@
             "uid": "prometheus-datasource-1"
           },
           "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "coremon_cpu_usage{namespace=\"default\", container_name!=\"corekube-core-monitor\"}",
+          "editorMode": "code",
+          "expr": "label_replace(label_replace(label_replace(coremon_cpu_usage{namespace=\"default\", container_name!=\"corekube-core-monitor\"}, \"name\", \"Worker $1\", \"pod_name\", \"corekube-worker-[^-]+-(.*)\"), \"name\", \"Frontend\", \"pod_name\", \"corekube-frontend-[^-]+-(.*)\"), \"name\", \"DB\", \"pod_name\", \"corekube-db-[^-]+-(.*)\")",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "{{pod_name}}",
+          "legendFormat": "{{name}}",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -420,12 +420,12 @@
             "uid": "prometheus-datasource-1"
           },
           "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "coremon_mem_usage{namespace=\"default\", container_name!=\"corekube-core-monitor\"}",
+          "editorMode": "code",
+          "expr": "label_replace(label_replace(label_replace(coremon_mem_usage{namespace=\"default\", container_name!=\"corekube-core-monitor\"}, \"name\", \"Worker $1\", \"pod_name\", \"corekube-worker-[^-]+-(.*)\"), \"name\", \"Frontend\", \"pod_name\", \"corekube-frontend-[^-]+-(.*)\"), \"name\", \"DB\", \"pod_name\", \"corekube-db-[^-]+-(.*)\")",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "{{pod_name}}",
+          "legendFormat": "{{name}}",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -591,11 +591,11 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "count(coremon_cpu_usage{namespace=\"default\", container_name=\"corekube-worker\"})",
+          "expr": "label_replace(count(coremon_cpu_usage{namespace=\"default\", container_name=\"corekube-worker\"}), \"name\", \"CK Worker Count\", \"\", \"\")",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "__auto",
+          "legendFormat": "{{name}}",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -689,11 +689,11 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "coremon_ue_count_last_5_seconds",
+          "expr": "label_replace(coremon_ue_count_last_5_seconds, \"name\", \"UEs Seen in last 5 Seconds\", \"\", \"\")",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "__auto",
+          "legendFormat": "{{name}} ",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -862,30 +862,16 @@
             "uid": "prometheus-datasource-1"
           },
           "disableTextWrap": false,
-          "editorMode": "code",
+          "editorMode": "builder",
           "exemplar": false,
-          "expr": "avg without (ue_id) (coremon_latency)",
+          "expr": "label_replace(label_replace(label_replace(label_replace(label_replace(avg without(ue_id) (coremon_latency), \"name\", \"Registration Request\", \"uplink_msg_type\", \"65\"), \"name\", \"Authentication\", \"uplink_msg_type\", \"87\"), \"name\", \"Registration Accept\", \"uplink_msg_type\", \"94\"), \"name\", \"5G PDU Session\", \"uplink_msg_type\", \"193\"), \"name\", \"Deregistration\", \"uplink_msg_type\", \"69\")",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "Up {{uplink_msg_type}} / Down {{downlink_msg_type}}",
+          "legendFormat": "{{name}}",
           "range": true,
           "refId": "Latency per msg type",
           "useBackend": false
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus-datasource-1"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "avg (coremon_latency)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "Average Latency"
         }
       ],
       "title": "CoreKube Latency",
@@ -961,6 +947,125 @@
       ],
       "title": "UEs",
       "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus-datasource-1"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Estimated packet rate",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "pps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus-datasource-1"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "label_replace(rate(coremon_downlink_packets_cumulative_total[$__rate_interval]), \"name\", \"Downlink\", \"\", \"\")",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{name}}",
+          "range": true,
+          "refId": "Downlink Packet Rate",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus-datasource-1"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "label_replace(rate(coremon_uplink_packets_cumulative_total[$__rate_interval]), \"name\", \"Uplink\", \"\", \"\")",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{name}}",
+          "range": true,
+          "refId": "Uplink Packet Rate",
+          "useBackend": false
+        }
+      ],
+      "title": "Packet Rate",
+      "transformations": [],
+      "type": "timeseries"
     }
   ],
   "refresh": "5s",
@@ -971,13 +1076,13 @@
     "list": []
   },
   "time": {
-    "from": "now-10m",
+    "from": "now-5m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "CoreKube Dashboard",
   "uid": "be3d8ddb-7d64-4ac5-b27c-3b771e5ec831",
-  "version": 7,
+  "version": 3,
   "weekStart": ""
 }

--- a/config/test/dashboards/main-dashboard.json
+++ b/config/test/dashboards/main-dashboard.json
@@ -74,10 +74,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           },
@@ -442,9 +438,6 @@
       "description": "",
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -458,7 +451,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "none"
         },
         "overrides": []
       },
@@ -470,8 +464,8 @@
       },
       "id": 8,
       "options": {
-        "colorMode": "value",
-        "graphMode": "area",
+        "colorMode": "background",
+        "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
@@ -565,7 +559,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
+        "h": 6,
         "w": 5,
         "x": 2,
         "y": 17
@@ -663,7 +657,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
+        "h": 6,
         "w": 5,
         "x": 7,
         "y": 17
@@ -722,8 +716,12 @@
                 "value": null
               },
               {
+                "color": "#EAB839",
+                "value": 5
+              },
+              {
                 "color": "red",
-                "value": 80
+                "value": 10
               }
             ]
           },
@@ -732,7 +730,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
+        "h": 6,
         "w": 2,
         "x": 12,
         "y": 17
@@ -837,7 +835,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
+        "h": 6,
         "w": 10,
         "x": 14,
         "y": 17
@@ -885,9 +883,6 @@
       },
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -901,20 +896,21 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "none"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 2,
         "x": 0,
         "y": 20
       },
       "id": 7,
       "options": {
-        "colorMode": "value",
-        "graphMode": "area",
+        "colorMode": "background",
+        "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
@@ -946,6 +942,89 @@
         }
       ],
       "title": "UEs",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus-datasource-1"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "pps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 0,
+        "y": 23
+      },
+      "id": 12,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus-datasource-1"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "label_replace(rate(coremon_downlink_packets_total[$__rate_interval]), \"name\", \"Downlink\", \"\", \"\")",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{name}}",
+          "range": true,
+          "refId": "Downlink Packet Rate",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus-datasource-1"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "label_replace(rate(coremon_uplink_packets_total[$__rate_interval]), \"name\", \"Uplink\", \"\", \"\")",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{name}}",
+          "range": true,
+          "refId": "Uplink Packet Rate",
+          "useBackend": false
+        }
+      ],
+      "title": "Packet Rate",
+      "transformations": [],
       "type": "stat"
     },
     {
@@ -1009,10 +1088,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 24
+        "h": 8,
+        "w": 20,
+        "x": 4,
+        "y": 23
       },
       "id": 11,
       "options": {
@@ -1036,7 +1115,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "label_replace(rate(coremon_downlink_packets_cumulative_total[$__rate_interval]), \"name\", \"Downlink\", \"\", \"\")",
+          "expr": "label_replace(rate(coremon_downlink_packets_total[$__rate_interval]), \"name\", \"Downlink\", \"\", \"\")",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -1052,7 +1131,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "label_replace(rate(coremon_uplink_packets_cumulative_total[$__rate_interval]), \"name\", \"Uplink\", \"\", \"\")",
+          "expr": "label_replace(rate(coremon_uplink_packets_total[$__rate_interval]), \"name\", \"Uplink\", \"\", \"\")",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -1083,6 +1162,6 @@
   "timezone": "",
   "title": "CoreKube Dashboard",
   "uid": "be3d8ddb-7d64-4ac5-b27c-3b771e5ec831",
-  "version": 3,
+  "version": 9,
   "weekStart": ""
 }

--- a/config/test/dashboards/main-dashboard.json
+++ b/config/test/dashboards/main-dashboard.json
@@ -1,0 +1,367 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus-datasource-1"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 1,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus-datasource-1"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Cores",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "si: cores"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus-datasource-1"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "coremon_cpu_usage{namespace=\"default\", container_name!=\"corekube-core-monitor\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{pod_name}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "CoreKube CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus-datasource-1"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Memory",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus-datasource-1"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "coremon_mem_usage{namespace=\"default\", container_name!=\"corekube-core-monitor\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{pod_name}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "CoreKube Memory Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus-datasource-1"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Latency (s)",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus-datasource-1"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "avg without (ue_id) (coremon_latency)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Up {{uplink_msg_type}} / Down {{downlink_msg_type}}",
+          "range": true,
+          "refId": "Latency per msg type",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus-datasource-1"
+          },
+          "editorMode": "code",
+          "expr": "avg (coremon_latency)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "Average Latency"
+        }
+      ],
+      "title": "CoreKube CPU Usage",
+      "transformations": [],
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "CoreKube Dashboard",
+  "uid": "be3d8ddb-7d64-4ac5-b27c-3b771e5ec831",
+  "version": 2,
+  "weekStart": ""
+}

--- a/config/test/dashboards/main-dashboard.json
+++ b/config/test/dashboards/main-dashboard.json
@@ -242,6 +242,109 @@
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus-datasource-1"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "count(coremon_cpu_usage{namespace=\"default\", container_name=\"corekube-worker\"})",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "Number of Workers",
+          "useBackend": false
+        }
+      ],
+      "title": "Number of CoreKube Workers",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus-datasource-1"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "Latency (s)",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -294,7 +397,7 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 0,
+        "x": 12,
         "y": 8
       },
       "id": 3,
@@ -342,7 +445,7 @@
           "refId": "Average Latency"
         }
       ],
-      "title": "CoreKube CPU Usage",
+      "title": "CoreKube Core Latency",
       "transformations": [],
       "type": "timeseries"
     }
@@ -355,13 +458,13 @@
     "list": []
   },
   "time": {
-    "from": "now-30m",
+    "from": "now-15m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "CoreKube Dashboard",
   "uid": "be3d8ddb-7d64-4ac5-b27c-3b771e5ec831",
-  "version": 2,
+  "version": 1,
   "weekStart": ""
 }

--- a/config/test/grafana.yaml
+++ b/config/test/grafana.yaml
@@ -68,6 +68,8 @@ data:
         isDefault: true
         version: 1
         editable: false
+        jsonData:
+          timeInterval: 5s
 
 ---
 
@@ -83,7 +85,7 @@ data:
     apiVersion: 1
     providers:
       - name: 'CoreKube Metrics'
-        updateIntervalSeconds: 10
+        updateIntervalSeconds: 5
         allowUiUpdates: true
         options:
           path: /var/lib/grafana/dashboards

--- a/config/test/grafana.yaml
+++ b/config/test/grafana.yaml
@@ -1,7 +1,15 @@
 apiVersion: v1
+kind: Namespace
+metadata:
+  name: grafana
+
+---
+
+apiVersion: v1
 kind: Service
 metadata:
   name: corekube-grafana
+  namespace: grafana
   labels:
     app: corekube-grafana
 spec:
@@ -20,6 +28,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: corekube-grafana-datasources
+  namespace: grafana
   labels:
     name: corekube-grafana-datasources
 data:
@@ -49,6 +58,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: corekube-grafana-dashboard-definition
+  namespace: grafana
   labels:
     name: corekube-grafana-dashboard-definition
 data:
@@ -70,6 +80,7 @@ metadata:
   labels:
     app: corekube-grafana
   name: corekube-grafana
+  namespace: grafana
 spec:
   selector:
     matchLabels:

--- a/config/test/grafana.yaml
+++ b/config/test/grafana.yaml
@@ -27,6 +27,20 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  name: corekube-grafana-main-config
+  namespace: grafana
+  labels:
+    name: corekube-grafana-main-config
+data:
+  grafana.ini: |-
+    [auth.anonymous]
+    enabled = true
+
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
   name: corekube-grafana-datasources
   namespace: grafana
   labels:
@@ -48,7 +62,7 @@ data:
         basicAuth:
         basicAuthUser:
         withCredentials:
-        isDefault:
+        isDefault: true
         version: 1
         editable: false
 
@@ -124,6 +138,8 @@ spec:
               cpu: 250m
               memory: 750Mi
           volumeMounts:
+            - mountPath: /etc/grafana
+              name: corekube-grafana-main-config-volume
             - mountPath: /etc/grafana/provisioning/datasources
               name: corekube-grafana-datasources-volume
             - mountPath: /etc/grafana/provisioning/dashboards
@@ -131,6 +147,9 @@ spec:
             - mountPath: /var/lib/grafana/dashboards
               name: corekube-grafana-dashboards-volume
       volumes:
+      - name: corekube-grafana-main-config-volume
+        configMap:
+          name: corekube-grafana-main-config
       - name: corekube-grafana-datasources-volume
         configMap:
           name: corekube-grafana-datasources

--- a/config/test/grafana.yaml
+++ b/config/test/grafana.yaml
@@ -1,0 +1,131 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: corekube-grafana
+  labels:
+    app: corekube-grafana
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 3000 # kubernetes-internal port
+      nodePort: 30010 # public port
+      protocol: TCP
+  selector:
+    app: corekube-grafana # selects the deployment by this match label
+  sessionAffinity: None
+
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: corekube-grafana-datasources
+  labels:
+    name: corekube-grafana-datasources
+data:
+  prometheus.yaml: |-
+    # https://grafana.com/docs/grafana/latest/administration/provisioning/
+    apiVersion: 1
+
+    datasources:
+      - name: CoreKube Prometheus
+        type: prometheus
+        access: proxy
+        orgId: 1
+        uid: prometheus-datasource-1
+        url: http://corekube-prometheus.prometheus.svc.cluster.local:9090
+        user:
+        database:
+        basicAuth:
+        basicAuthUser:
+        withCredentials:
+        isDefault:
+        version: 1
+        editable: false
+
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: corekube-grafana-dashboard-definition
+  labels:
+    name: corekube-grafana-dashboard-definition
+data:
+  dashboards.yaml: |-
+    apiVersion: 1
+    providers:
+      - name: 'CoreKube Metrics'
+        updateIntervalSeconds: 10
+        allowUiUpdates: true
+        options:
+          path: /var/lib/grafana/dashboards
+          foldersFromFilesStructure: true
+        type: file
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: corekube-grafana
+  name: corekube-grafana
+spec:
+  selector:
+    matchLabels:
+      app: corekube-grafana
+  template:
+    metadata:
+      labels:
+        app: corekube-grafana
+    spec:
+      securityContext:
+        fsGroup: 472
+        supplementalGroups:
+          - 0
+      containers:
+        - name: grafana
+          image: grafana/grafana-oss:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 3000 # kubernetes-internal port
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /robots.txt
+              port: 3000
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 2
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            tcpSocket:
+              port: 3000
+            timeoutSeconds: 1
+          resources:
+            requests:
+              cpu: 250m
+              memory: 750Mi
+          volumeMounts:
+            - mountPath: /etc/grafana/provisioning/datasources
+              name: corekube-grafana-datasources-volume
+            - mountPath: /etc/grafana/provisioning/dashboards
+              name: corekube-grafana-dashboard-definition-volume
+            - mountPath: /var/lib/grafana/dashboards
+              name: corekube-grafana-dashboards-volume
+      volumes:
+      - name: corekube-grafana-datasources-volume
+        configMap:
+          name: corekube-grafana-datasources
+      - name: corekube-grafana-dashboard-definition-volume
+        configMap:
+          name: corekube-grafana-dashboard-definition
+      - name: corekube-grafana-dashboards-volume
+        configMap:
+          name: corekube-grafana-dashboards

--- a/config/test/grafana.yaml
+++ b/config/test/grafana.yaml
@@ -36,6 +36,9 @@ data:
     [auth.anonymous]
     enabled = true
 
+    [users]
+    home_page = /d/be3d8ddb-7d64-4ac5-b27c-3b771e5ec831/corekube-dashboard
+
 ---
 
 apiVersion: v1

--- a/config/test/prometheus.yaml
+++ b/config/test/prometheus.yaml
@@ -9,9 +9,9 @@ data:
     global:
       scrape_interval: 1s
     scrape_configs:
-      - job_name: core-monitor
+      - job_name: corekube-metrics-monitor
         static_configs:
-        - targets: ['corekube-core-monitor:5050'] # Kubernetes DNS will resolve this to the corresponding service
+        - targets: ['corekube-metrics-export-service:5050'] # Kubernetes DNS will resolve this to the corresponding service
 ---
 apiVersion: v1
 kind: Service

--- a/config/test/prometheus.yaml
+++ b/config/test/prometheus.yaml
@@ -1,7 +1,15 @@
 apiVersion: v1
+kind: Namespace
+metadata:
+  name: prometheus
+
+---
+
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: corekube-prometheus-conf
+  namespace: prometheus
   labels:
     name: corekube-prometheus-conf
 data:
@@ -11,11 +19,12 @@ data:
     scrape_configs:
       - job_name: corekube-metrics-monitor
         static_configs:
-        - targets: ['corekube-metrics-export-service:5050'] # Kubernetes DNS will resolve this to the corresponding service
+        - targets: ['corekube-metrics-export-service.default.svc.cluster.local:5050'] # Kubernetes DNS will resolve this to the corresponding service
 ---
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: prometheus
   name: corekube-prometheus
   labels:
     app: corekube-prometheus
@@ -47,6 +56,7 @@ spec:
         image: prom/prometheus
         args:
           - "--config.file=/etc/prometheus/prometheus.yml"
+          - "--web.listen-address=0.0.0.0:9090"
         ports:
         - containerPort: 9090
         volumeMounts:

--- a/config/test/prometheus.yaml
+++ b/config/test/prometheus.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: corekube-prometheus-conf
+  labels:
+    name: corekube-prometheus-conf
+data:
+  prometheus.yml: |-
+    global:
+      scrape_interval: 1s
+    scrape_configs:
+      - job_name: core-monitor
+        static_configs:
+        - targets: ['corekube-core-monitor:5050'] # Kubernetes DNS will resolve this to the corresponding service
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: corekube-prometheus
+  labels:
+    app: corekube-prometheus
+spec:
+  type: ClusterIP
+  selector:
+    app: corekube-prometheus
+  ports:
+  - port: 9090
+    targetPort: 9090
+    protocol: TCP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: corekube-prometheus
+spec:
+  selector:
+    matchLabels:
+      app: corekube-prometheus
+  template:
+    metadata:
+      labels:
+        app: corekube-prometheus
+    spec:
+      containers:
+      - name: prometheus
+        image: prom/prometheus
+        args:
+          - "--config.file=/etc/prometheus/prometheus.yml"
+        ports:
+        - containerPort: 9090
+        volumeMounts:
+        - name: corekube-prometheus-config-volume
+          mountPath: /etc/prometheus/
+      volumes:
+      - name: corekube-prometheus-config-volume
+        configMap:
+          name: corekube-prometheus-conf

--- a/config/test/prometheus.yaml
+++ b/config/test/prometheus.yaml
@@ -32,6 +32,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: corekube-prometheus
+  namespace: prometheus
 spec:
   selector:
     matchLabels:

--- a/scripts/ck_5g_master.sh
+++ b/scripts/ck_5g_master.sh
@@ -182,9 +182,9 @@ sudo kubectl create -f config/test/5G/deployment.yaml
 # Deploy Prometheus
 sudo kubectl create -f config/test/prometheus.yaml
 
-sudo kubectl create configmap corekube-grafana-dashboards --namespace=grafana --from-file=config/test/dashboards/
 # Deploy Grafana
 sudo kubectl create -f config/test/grafana.yaml
+sudo kubectl create configmap corekube-grafana-dashboards --namespace=grafana --from-file=config/test/dashboards/
 
 # Install tshark
 sudo add-apt-repository -y ppa:wireshark-dev/stable

--- a/scripts/ck_5g_master.sh
+++ b/scripts/ck_5g_master.sh
@@ -120,8 +120,9 @@ echo "Port-forwarding port 80 of dashboard service at public port 12345..."
 # kubectl port-forward will fail. This adds a slight delay to the setup but it
 # should be very negligible because we've moved the waiting/port-forwarding to
 # after the helm installation above, which should give it enough time to start
-# up in the background. 
-kubectl wait -n grafana --for=condition=ready pod --all
+# up in the background. If not, we will wait up to 10 minutes instead of the
+# default 30 seconds.
+kubectl wait -n grafana --for=condition=ready pod --all --timeout=10m
 sudo kubectl port-forward services/corekube-grafana -n grafana --address='0.0.0.0' 12345:3000 &
 
 # Install metrics-server for HPA

--- a/scripts/ck_5g_master.sh
+++ b/scripts/ck_5g_master.sh
@@ -182,6 +182,10 @@ sudo kubectl create -f config/test/5G/deployment.yaml
 # Deploy Prometheus
 sudo kubectl create -f config/test/prometheus.yaml
 
+sudo kubectl create configmap corekube-grafana-dashboards --from-file=config/test/dashboards/
+# Deploy Grafana
+sudo kubectl create -f config/test/grafana.yaml
+
 # Install tshark
 sudo add-apt-repository -y ppa:wireshark-dev/stable
 sudo apt update

--- a/scripts/ck_5g_master.sh
+++ b/scripts/ck_5g_master.sh
@@ -179,6 +179,8 @@ ASD
 sudo kubectl create -f config/test/metrics-server.yaml
 # Deploy Test Core
 sudo kubectl create -f config/test/5G/deployment.yaml
+# Deploy Prometheus
+sudo kubectl create -f config/test/prometheus.yaml
 
 # Install tshark
 sudo add-apt-repository -y ppa:wireshark-dev/stable

--- a/scripts/ck_5g_master.sh
+++ b/scripts/ck_5g_master.sh
@@ -182,7 +182,7 @@ sudo kubectl create -f config/test/5G/deployment.yaml
 # Deploy Prometheus
 sudo kubectl create -f config/test/prometheus.yaml
 
-sudo kubectl create configmap corekube-grafana-dashboards --from-file=config/test/dashboards/
+sudo kubectl create configmap corekube-grafana-dashboards --namespace=grafana --from-file=config/test/dashboards/
 # Deploy Grafana
 sudo kubectl create -f config/test/grafana.yaml
 

--- a/scripts/ck_5g_master.sh
+++ b/scripts/ck_5g_master.sh
@@ -77,6 +77,7 @@ sudo chown ${username}:${usergid} $KUBEHOME/admin.conf
 
 # Install Flannel. See https://github.com/coreos/flannel
 sudo kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
+sudo kubectl get daemonset -n kube-flannel kube-flannel-ds -o json | jq '.spec.template.spec.containers[0].args += ["--iface-regex=192\\.168\\..*\\..*"]' | sudo kubectl replace -f -
 
 # use this to enable autocomplete
 source <(kubectl completion bash)

--- a/scripts/ck_master.sh
+++ b/scripts/ck_master.sh
@@ -76,6 +76,7 @@ sudo chown ${username}:${usergid} $KUBEHOME/admin.conf
 
 # Install Flannel. See https://github.com/coreos/flannel
 sudo kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
+sudo kubectl get daemonset -n kube-flannel kube-flannel-ds -o json | jq '.spec.template.spec.containers[0].args += ["--iface-regex=192\\.168\\..*\\..*"]' | sudo kubectl replace -f -
 
 # use this to enable autocomplete
 source <(kubectl completion bash)

--- a/scripts/master.sh
+++ b/scripts/master.sh
@@ -81,6 +81,7 @@ sudo chown ${username}:${usergid} $KUBEHOME/admin.conf
 
 # Install Flannel. See https://github.com/coreos/flannel
 sudo kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
+sudo kubectl get daemonset -n kube-flannel kube-flannel-ds -o json | jq '.spec.template.spec.containers[0].args += ["--iface-regex=192\\.168\\..*\\..*"]' | sudo kubectl replace -f -
 
 # use this to enable autocomplete
 source <(kubectl completion bash)


### PR DESCRIPTION
This PR fully implements the Grafana based monitoring for 5G CoreKube, at port 12345, replacing the previous dashboard. 

This PR contains the changes for #7 and #9 - this is so that the YutoNervionTest profile on Nervion is fully ready for use at MobiCom. 

Recommended merge strategy: Merge #7, #9, then #8.