### PR TITLE
Fix Flannel using the public interface for inter-host communications

### DIFF
--- a/scripts/ck_5g_master.sh
+++ b/scripts/ck_5g_master.sh
@@ -77,6 +77,7 @@ sudo chown ${username}:${usergid} $KUBEHOME/admin.conf
 
 # Install Flannel. See https://github.com/coreos/flannel
 sudo kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
+sudo kubectl get daemonset -n kube-flannel kube-flannel-ds -o json | jq '.spec.template.spec.containers[0].args += ["--iface-regex=192\\.168\\..*\\..*"]' | sudo kubectl replace -f -
 
 # use this to enable autocomplete
 source <(kubectl completion bash)

--- a/scripts/ck_master.sh
+++ b/scripts/ck_master.sh
@@ -76,6 +76,7 @@ sudo chown ${username}:${usergid} $KUBEHOME/admin.conf
 
 # Install Flannel. See https://github.com/coreos/flannel
 sudo kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
+sudo kubectl get daemonset -n kube-flannel kube-flannel-ds -o json | jq '.spec.template.spec.containers[0].args += ["--iface-regex=192\\.168\\..*\\..*"]' | sudo kubectl replace -f -
 
 # use this to enable autocomplete
 source <(kubectl completion bash)

--- a/scripts/master.sh
+++ b/scripts/master.sh
@@ -81,6 +81,7 @@ sudo chown ${username}:${usergid} $KUBEHOME/admin.conf
 
 # Install Flannel. See https://github.com/coreos/flannel
 sudo kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
+sudo kubectl get daemonset -n kube-flannel kube-flannel-ds -o json | jq '.spec.template.spec.containers[0].args += ["--iface-regex=192\\.168\\..*\\..*"]' | sudo kubectl replace -f -
 
 # use this to enable autocomplete
 source <(kubectl completion bash)


### PR DESCRIPTION
**Merge after #10**

Currently, Nervion and core deployments use the public network when they communicate through Flannel, as the Flannel VXLAN goes over the public interface.

`flanneld` accepts arguments to specify an interface for use for inter-host communication: https://github.com/flannel-io/flannel/blob/master/Documentation/configuration.md

The arguments can be any of `iface`, `iface-regex`, or `iface-can-reach`.

The default Kubernetes config YAML file that we use for `kube-flannel` does not specify any of these arguments, so flannel uses "the interface for the default route on the machine," which on Powder machines happens to be the public interface.

This PR dynamically patches the configuration by adding an `--iface-regex` argument, making flannel use whatever is the interface that has the local `192\.168\..*\..*` (regex, dots escaped) IP address. 